### PR TITLE
Moved from requirements.txt approach to setup.py install_requires.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-Django
-PIL
-django-piston
-restkit
-wsgiref
-simplejson
-djangorestframework
-django-filter

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,15 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
-    ]
+    ],
+    install_requires = [
+        'Django',
+        'restkit',
+        'wsgiref',
+        'simplejson',
+    ],
+    extra_requires = {
+        'Piston-tests': ['django-piston'],
+        'DRF-tests'   : ['djangorestframework']
+    }
 )


### PR DESCRIPTION
If django-roa is listed as a dependency by another python program, pip just won't install its own dependencies.

`requirements.txt` is bad for libraries.

Moreover, I did some cleanup :
- PIL is not used -> removed
- djangorestframework and django-piston are here just fore unit tests -> I put them as extra_requires.
