### PR TITLE
djangorestframework is not a test_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
         'restkit',
         'wsgiref',
         'simplejson',
+        'djangorestframework'
     ],
     tests_require={
         'Piston-tests': ['django-piston'],
-        'DRF-tests': ['djangorestframework']
     }
 )


### PR DESCRIPTION
I though in #5 DRF was only used for testing but it's used in the very core of ROA for parsers/renderers like in https://github.com/charles-vdulac/django-roa/blob/master/django_roa/db/models.py#L25
