### PR TITLE
fixes attributeerror while iterating on un-paginated DRF empty response

### DIFF
--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -213,12 +213,15 @@ class RemoteQuerySet(query.QuerySet):
 
         # Deserializing objects:
         data = self.model.get_parser().parse(StringIO(response))
-        serializer = self.model.get_serializer(data=data)
-        if not serializer.is_valid():
-            raise ROAException(u'Invalid deserialization for {} model: {}'.format(self.model, serializer.errors))
 
-        for obj in serializer.object:
-            yield obj
+        # [] is the case of empty no-paginated result
+        if data != []:
+            serializer = self.model.get_serializer(data=data)
+            if not serializer.is_valid():
+                raise ROAException(u'Invalid deserialization for {} model: {}'.format(self.model, serializer.errors))
+
+            for obj in serializer.object:
+                yield obj
 
     def count(self):
         """

--- a/examples/django_rest_framework/backend/backend/api/views.py
+++ b/examples/django_rest_framework/backend/backend/api/views.py
@@ -26,6 +26,8 @@ class ArticleViewSet(ModelViewSet):
 class TagViewSet(ModelViewSet):
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
+    # Do not paginate the tags, for unpaginated testing
+    paginate_by = None
 
 
 # Reversed

--- a/examples/django_rest_framework/frontend/frontend/tests.py
+++ b/examples/django_rest_framework/frontend/frontend/tests.py
@@ -149,3 +149,13 @@ class ROATestCase(APITestCase):
         article = Article.objects.get(headline="James's story")
         self.assertEqual(article.reporter.first_name, 'James')
         self.assertEqual(article.reporter.account.email, 'james@example.com')
+
+
+    def test_empty_list_no_pagination(self):
+        tags = Tag.objects.filter(label='idonetexist')
+
+        # To check that iterating over the empty queryset works
+        for i in tags:
+            pass
+
+        self.assertEqual(tags.count(), 0)


### PR DESCRIPTION
Similar to #10 but with test (passing).
