### PR TITLE
headers is not a valid kwargs for Resource.__init__() removed

### DIFF
--- a/django_roa/db/models.py
+++ b/django_roa/db/models.py
@@ -456,7 +456,6 @@ class ROAModel(models.Model):
                 # consider it might be inserting so check it first
                 # @todo: try to improve this block to check if custom pripary key is not None first
                 resource = Resource(self.get_resource_url_detail(),
-                                    headers=headers,
                                     filters=ROA_FILTERS)
                 try:
                     response = resource.get(payload=None, **get_args)
@@ -518,7 +517,6 @@ class ROAModel(models.Model):
 
         # Deletion in cascade should be done server side.
         resource = Resource(self.get_resource_url_detail(),
-                            headers=get_roa_headers(),
                             filters=ROA_FILTERS)
 
         logger.debug(u"""Deleting  : "%s" through %s""" % \

--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -195,7 +195,6 @@ class RemoteQuerySet(query.QuerySet):
         remote web service.
         """
         resource = Resource(self.model.get_resource_url_list(),
-                            headers=self._get_http_headers(),
                             filters=ROA_FILTERS)
         try:
             parameters = self.query.parameters
@@ -234,7 +233,6 @@ class RemoteQuerySet(query.QuerySet):
         # for all model without relying on get_resource_url_list
         instance = clone.model()
         resource = Resource(instance.get_resource_url_count(),
-                            headers=self._get_http_headers(),
                             filters=ROA_FILTERS)
         try:
             parameters = clone.query.parameters
@@ -267,7 +265,6 @@ class RemoteQuerySet(query.QuerySet):
         else:
             instance.pk = pk
         resource = Resource(instance.get_resource_url_detail(),
-                            headers=self._get_http_headers(),
                             filters=ROA_FILTERS,
                             **kwargs)
         try:


### PR DESCRIPTION
1) this arg was not taken into account
2) if you do a http_s_ request, it will be considered as a **ssl** argument and issue an error (as `headers` is not a valid ssl parameter).

The custom headers should be passed at request time (as it's already done in relevant parts of code).
