### PR TITLE
Include ROA headers on GET (.save_base) and DELETE (.delete)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='django-roa',
-    version='1.7',
+    version='1.7.2',
     url='http://code.welldev.org/django-roa/wiki/Home',
     download_url='http://code.welldev.org/django-roa/downloads/',
     license='BSD',


### PR DESCRIPTION
- Also set 'format' GET arg using mapped argument name

This replaces the hard-coded GET argument of `format` with the mapped argument name from `settings.ROA_ARGS_NAMES_MAPPING`, but still defaults to `format` if a mapping for that argument is not found. This is important if the remote service does not accept a `?format=` argument and has a different one.

This also make all of the resource calls consistent when saving or deleting objects, to include the ROA headers on `resource.get()` calls made within `django_roa.db.models.ROAModel.save_base()`, and on `resource.delete()` calls made within `django_roa.db.models.ROAModel.delete()`.

I took the liberty of versioning this commit as `1.7.2` inside of `setup.py`.
