### PR TITLE
Add method values_list to ROA's queryset

### DIFF
--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -71,6 +71,9 @@ class Query(object):
         self.limit_stop = stop
         self.filterable = False
 
+    def has_filters(self):
+        return self.where
+
     def add_select_related(self, fields):
         """
         Sets up the select_related data structure so that we only select

--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -371,6 +371,20 @@ class RemoteQuerySet(query.QuerySet):
         self._result_cache = None
     delete.alters_data = True
 
+    def values_list(self, *fields, **kwargs):
+        flat = kwargs.pop('flat', False)
+        if kwargs:
+            raise TypeError('Unexpected keyword arguments to values_list')
+        if flat and len(fields) > 1:
+            raise TypeError("'flat' is not valid when values_list is called with more than one field.")
+
+        def parse_fields(instance):
+            if flat:
+                return getattr(instance, fields[0])
+            else:
+                return tuple([getattr(instance, field) for field in fields])
+        return map(parse_fields, self)
+
     ##################################################################
     # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
     ##################################################################

--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -17,6 +17,7 @@ from django.utils.encoding import force_unicode
 
 from restkit import Resource, ResourceNotFound
 from django_roa.db.exceptions import ROAException, ROANotImplementedYetException
+from copy import deepcopy
 
 logger = logging.getLogger("django_roa")
 
@@ -50,7 +51,7 @@ class Query(object):
         return self.filterable
 
     def clone(self):
-        return self
+        return deepcopy(self)
 
     def clear_ordering(self):
         self.order_by = []


### PR DESCRIPTION
Using the values_list of the default Django queryset with a ROA Model didn't work so I made compatible making a function that overwrites the original.
